### PR TITLE
Using static runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
+# for using MSVC runtime library flags
+cmake_policy(SET CMP0091 NEW)
+
+# forces a statically-linked runtime library
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 # set the project name
 project(RayTracer VERSION 0.1)
 


### PR DESCRIPTION
For some reason tests were being built with dynamically linked runtime when using MSVC. I am setting `CMAKE_MSVC_RUNTIME_LIBRARY` to explicitly use statically linked runtime. For more info read this
https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html and this https://cmake.org/cmake/help/latest/policy/CMP0091.html#policy:CMP0091

This flag will be skipped for other compilers, so no need to check for MSVC explicitly.